### PR TITLE
adds .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.py[cod]
+*$py.class


### PR DESCRIPTION
Adds gitignore.  It's common practice not to commit your compiled `.pyc` files.

Run this to stop tracking the committed file
```
git rm --cached ultrasonic_distance.pyc
```